### PR TITLE
update widget.py for django>2.1

### DIFF
--- a/camera_imagefield/widgets.py
+++ b/camera_imagefield/widgets.py
@@ -19,7 +19,7 @@ class CameraImageWidget(FileInput):
     def use_required_attribute(self, initial):
         return False
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         field = super(CameraImageWidget, self).render(name, value, attrs)
         return mark_safe("""<div class="camera-imagefield" data-name={}>{}</div>""".format(escape(name), field))
 


### PR DESCRIPTION
According to https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1 ,
Support for Widget.render() methods without the renderer argument is removed.

This bugfix just add the argument.